### PR TITLE
Remove `Transitions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,13 @@ The delay is tracked per device and applied once.
 
 ### Core Methods
 
-| Method                      | Description               |
-|-----------------------------|---------------------------|
-| `loadAppOpenAd()`           | Load the ad               |
-| `isAdAvailable(): Boolean`  | Check if ad is ready      |
-| `clearAdInstance()`         | Remove ad instance        |
-| `setImmersiveMode(Boolean)` | Toggle immersive mode     |
-| `showAdWithDelay(Long)`     | Delay ad display (ms)     |
-| `setAdTransition(Int, Int)` | Set enter/exit animations |
+| Method                      | Description           |
+|-----------------------------|-----------------------|
+| `loadAppOpenAd()`           | Load the ad           |
+| `isAdAvailable(): Boolean`  | Check if ad is ready  |
+| `clearAdInstance()`         | Remove ad instance    |
+| `setImmersiveMode(Boolean)` | Toggle immersive mode |
+| `showAdWithDelay(Long)`     | Delay ad display (ms) |
 
 ### Event Listeners
 

--- a/README.md
+++ b/README.md
@@ -160,12 +160,6 @@ showOnCondition = {
 }
 ```
 
-Custom transitions:
-
-```kotlin
-setAdTransition(R.anim.fade_in, R.anim.fade_out)
-```
-
 Add a brief delay before showing:
 
 ```kotlin

--- a/library/src/main/java/com/lazygeniouz/aoa/AppOpenAdManager.kt
+++ b/library/src/main/java/com/lazygeniouz/aoa/AppOpenAdManager.kt
@@ -1,8 +1,6 @@
 package com.lazygeniouz.aoa
 
-import android.app.Activity
 import android.app.Application
-import android.os.Build
 import android.os.Handler
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.FullScreenContentCallback
@@ -85,14 +83,6 @@ class AppOpenAdManager private constructor(
     }
 
     /**
-     * Use an activity animation when the Ad is shown,
-     * similar to [Activity.overridePendingTransition] or [Activity.overrideActivityTransition].
-     */
-    fun setAdTransition(enterAnim: Int, exitAnim: Int) {
-        this.adEnterTransition = enterAnim to exitAnim
-    }
-
-    /**
      * Set a delay for showing the AppOpenAd.
      *
      * The [AppOpenAdListener.onAdWillShow] will be invoked
@@ -121,9 +111,6 @@ class AppOpenAdManager private constructor(
     /**
      * Returns the [AppOpenAd] instance, can be **null** if it is not loaded yet.
      *
-     * **Note:** If you manually use `getAppOpenAd().show(activity)`,
-     * then the [setAdTransition] will not work, but you may also use
-     * [Activity.overridePendingTransition] or [Activity.overrideActivityTransition].
      * @return [AppOpenAd]
      */
     fun getAppOpenAd(): AppOpenAd? {
@@ -209,25 +196,11 @@ class AppOpenAdManager private constructor(
                     listener?.onAdWillShow()
                     Handler(activity.mainLooper).postDelayed({
                         appOpenAd.show(activity)
-                        applyAdEnterTransition(activity)
                     }, this.adShowDelayPeriod)
                 } else {
                     appOpenAd.show(activity)
-                    applyAdEnterTransition(activity)
                 }
             }
-        }
-    }
-
-    private fun applyAdEnterTransition(activity: Activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            activity.overrideActivityTransition(
-                Activity.OVERRIDE_TRANSITION_OPEN,
-                adEnterTransition.first, adEnterTransition.second
-            )
-        } else {
-            @Suppress("deprecation")
-            activity.overridePendingTransition(adEnterTransition.first, adEnterTransition.second)
         }
     }
 

--- a/library/src/main/java/com/lazygeniouz/aoa/base/BaseAdManager.kt
+++ b/library/src/main/java/com/lazygeniouz/aoa/base/BaseAdManager.kt
@@ -19,7 +19,7 @@ import com.lazygeniouz.aoa.configs.Configs
 import com.lazygeniouz.aoa.idelay.InitialDelay
 import com.lazygeniouz.aoa.listener.AppOpenAdListener
 import java.time.Instant
-import java.util.*
+import java.util.Date
 import java.util.concurrent.TimeUnit
 
 /**
@@ -60,7 +60,6 @@ abstract class BaseAdManager(
     protected var isImmersive: Boolean = false
     protected var adShowDelayPeriod: Long = 1000
     protected var coldShowListener: (() -> Unit)? = null
-    protected var adEnterTransition: Pair<Int, Int> = 0 to 0
 
     protected var isLoading = false
     protected var isShowingAd = false


### PR DESCRIPTION
They no longer work.
Instead if needed, you can still override for the `AdActivity` like -

```xml
<!-- Your app's AndroidManifest.xml -->
<activity
    android:name="com.google.android.gms.ads.AdActivity"
    android:theme="@style/AdActivityTheme"
    tools:replace="android:theme" />
```
and then -
```xml
<!-- Your app's styles.xml -->
<style name="AdActivityTheme" parent="@android:style/Theme.Translucent">
    <item name="android:windowAnimationStyle">@style/AdActivityAnimation</item>
</style>

<style name="AdActivityAnimation" parent="@android:style/Animation.Activity">
    <item name="android:activityOpenEnterAnimation">@anim/slide_in_right</item>
    <item name="android:activityOpenExitAnimation">@anim/slide_out_left</item>
</style>
```